### PR TITLE
content and navbar links now scroll without visible scrollbar

### DIFF
--- a/src/assets/components/_content.scss
+++ b/src/assets/components/_content.scss
@@ -11,7 +11,7 @@
 
   .rightSection {
     height: 100%;
-    overflow-y: scroll;
+    @include scrollWithoutScrollbar;
     position: relative;
   }
 

--- a/src/assets/components/_dynamicNavbar.scss
+++ b/src/assets/components/_dynamicNavbar.scss
@@ -28,6 +28,8 @@
 
   .links {
     margin-top: 25px;
+    height: 100%;
+    @include scrollWithoutScrollbar;
   }
 
   .navItem {

--- a/src/assets/designLanguage/_variables.scss
+++ b/src/assets/designLanguage/_variables.scss
@@ -23,3 +23,12 @@ $darkNavbar: #393e41;
 .w-80 {
   width: 80%;
 }
+
+@mixin scrollWithoutScrollbar {
+  overflow-y: scroll;
+  &::-webkit-scrollbar {
+    width: 0 !important;
+  }
+  overflow: -moz-scrollbars-none;
+  ms-overflow-style: none;
+}


### PR DESCRIPTION
creates mixin that allows vertical scrolling on an element without showing the scrollbar