### PR TITLE
YADA-132 fixes Nivo graphs

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     },
     "scripts": {
         "start": "craco start",
-        "build": "craco build && cp _redirects build/_redirects",
+        "build": "node patch-react-spring.js && craco build && cp _redirects build/_redirects",
         "test": "craco test",
         "eject": "react-scripts eject"
     },

--- a/patch-react-spring.js
+++ b/patch-react-spring.js
@@ -1,0 +1,36 @@
+/**
+ * This file patches Nivo such that the recent updates to React Spring do not break tooltips.
+ */
+
+const fs = require('fs')
+const path = require('path')
+
+const packagesToPatch = [
+    'animated',
+    'core',
+    'konva',
+    'native',
+    'shared',
+    'three',
+    'web',
+    'zdog',
+]
+
+packagesToPatch.forEach(patchPackage)
+
+function patchPackage(package) {
+    const packageJsonPath = path.join(
+        'node_modules',
+        '@react-spring',
+        package,
+        'package.json',
+    )
+    const packageJson = fs.readFileSync(packageJsonPath, 'utf-8')
+    const modifiedPackageJson = packageJson.replace(
+        '"sideEffects": false,',
+        '',
+    )
+    fs.writeFileSync(packageJsonPath, modifiedPackageJson, {
+        encoding: 'utf-8',
+    })
+}


### PR DESCRIPTION
Adds script `patch-react-spring.js` that patches Nivo as per [this issue](https://github.com/plouc/nivo/issues/1290). Added script to `yarn build` command so that it gets run first before deployment.