### PR TITLE
Prevents unauthorized equipment edits

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,8 +2,20 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
-    render(<App />);
-    const linkElement = screen.getByText(/learn react/i);
-    expect(linkElement).toBeInTheDocument();
+import { isAlphabetical, isPhoneNumber } from 'scripts/DataValidation';
+describe('Verifies proper input sanitization', () => {
+    test('every letter in the alphabet should be valid', () => {
+        const raw = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+        expect(isAlphabetical(raw)).toBe(true);
+    });
+    test('White space characters should be accepted', () => {
+        const raw = ' a b \t c d e \n g';
+        expect(isAlphabetical(raw)).toBe(true);
+    });
+    test('Common url characters should be rejected', () => {
+        const raw = ['?', '.', '@', '#', '/', '\\', '~', ':'];
+        raw.forEach((character) => {
+            expect(isAlphabetical(character)).toBe(false);
+        });
+    });
 });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,20 +2,101 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-import { isAlphabetical, isPhoneNumber } from 'scripts/DataValidation';
-describe('Verifies proper input sanitization', () => {
+import { isValidName, isPhoneNumber } from 'scripts/DataValidation';
+describe('Verifies proper input sanitization for isVAlidName', () => {
+    // expects tests to pass
     test('every letter in the alphabet should be valid', () => {
         const raw = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
-        expect(isAlphabetical(raw)).toBe(true);
+        expect(isValidName(raw)).toBe(true);
+    });
+    test('every number in 0-9 should be valid', () => {
+        const raw = [
+            '0',
+            '1',
+            '2',
+            '3',
+            '4',
+            '5',
+            '6',
+            '7',
+            '8',
+            '9',
+            '0123456789',
+        ];
+        raw.forEach((number) => expect(isValidName(number)).toBe(true));
+    });
+    test('dashes should be valid', () => {
+        const raw = ['asdf-asdf', 'asdf-'];
+        raw.forEach((input) => expect(isValidName(input)).toBe(true));
     });
     test('White space characters should be accepted', () => {
         const raw = ' a b \t c d e \n g';
-        expect(isAlphabetical(raw)).toBe(true);
+        expect(isValidName(raw)).toBe(true);
     });
+    // expects tests to fails
     test('Common url characters should be rejected', () => {
-        const raw = ['?', '.', '@', '#', '/', '\\', '~', ':'];
+        const raw = ['?', '.', '@', '#', '/', '\\', '~', ':', '!'];
         raw.forEach((character) => {
-            expect(isAlphabetical(character)).toBe(false);
+            expect(isValidName(character)).toBe(false);
         });
+    });
+    test('Expects empty string to fail', () => {
+        const raw = '';
+        expect(isValidName(raw)).toBe(false);
+    });
+    test('Expects "?asdf!" to fail', () => {
+        expect(isValidName('?asdf!')).toBe(false);
+    });
+    test('Expect strings without a single letter or number to fail', () => {
+        const raw = ['-', ' ', '  ', '\t', ''];
+        raw.forEach((testString) =>
+            expect(isValidName(testString)).toBe(false)
+        );
+    });
+});
+
+describe('Verifies proper phone number sanitization for isPhoneNumber', () => {
+    // expect success
+    test(`verifies the format '(123) 456-7890'`, () => {
+        const raw = '(123) 456-7890';
+        expect(isPhoneNumber(raw)).toBe(true);
+    });
+    test(`verifies the format (123)456-7890`, () => {
+        const raw = '(123)456-7890';
+        expect(isPhoneNumber(raw)).toBe(true);
+    });
+    test(`verifies the format 123-456-7890`, () => {
+        const raw = '123-456-7890';
+        expect(isPhoneNumber(raw)).toBe(true);
+    });
+    test('verifies the format 123.456.7890', () => {
+        const raw = '123.456.7890';
+        expect(isPhoneNumber(raw)).toBe(true);
+    });
+    test('verifies the format 1234567890', () => {
+        const raw = '1234567890';
+        expect(isPhoneNumber(raw)).toBe(true);
+    });
+    test('verifies the format +31636363634', () => {
+        const raw = '+31636363634';
+        expect(isPhoneNumber(raw)).toBe(true);
+    });
+    test('verifies the format 075-63546725', () => {
+        const raw = '075-63546725';
+        expect(isPhoneNumber(raw)).toBe(true);
+    });
+
+    // expect failures
+    test('verifies empty string to fail', () => {
+        const raw = '';
+        expect(isPhoneNumber(raw)).toBe(false);
+    });
+    test('expects short phone numbers to fail', () => {
+        const raw = '123456789';
+        expect(isPhoneNumber(raw)).toBe(false);
+    });
+    test('expects a bunch of malformed strings to fail', () => {
+        const raw = ['a', '123456789a', '123456789+0', '+1(123)456-789'];
+        raw.forEach((number) => expect(isPhoneNumber(number)).toBe(false));
     });
 });

--- a/src/components/Onboard/ChangePassword.tsx
+++ b/src/components/Onboard/ChangePassword.tsx
@@ -65,7 +65,7 @@ export default function ChangePassword() {
                             type="password"
                             name="oldPassword"
                             id="oldPassword"
-                            placeholder="currentPassword"
+                            placeholder="current password"
                         />
                         <Input
                             required

--- a/src/components/Site/SiteConfigContent.tsx
+++ b/src/components/Site/SiteConfigContent.tsx
@@ -28,7 +28,7 @@ import { ToggleSwitch } from 'components/Control/ToggleSwitch';
 import { Redirect } from 'react-router';
 import { useHistory } from 'react-router-dom';
 import PrivilegeAssert from 'components/Control/PrivilegeAssert';
-import { isAlphabetical } from 'scripts/DataValidation';
+import { isValidName } from 'scripts/DataValidation';
 
 interface configTabProps {
     site: SiteObject;
@@ -109,11 +109,15 @@ export default function ConfigTab({
     });
 
     const updateField = (e: any) => {
-        if (e.target.id === 'name' && !isAlphabetical(e.currentTarget.value)) {
-            alert(
-                'Invalid input: the name of a site must only contain alphabetical characters'
-            );
-            return;
+        if (e.target.id === 'name' && !isValidName(e.currentTarget.value)) {
+            if (e.currentTarget.value === '') {
+                alert('A blank name will not be accepted');
+            } else {
+                alert(
+                    'Invalid input: the name of a site must only contain alphabetical characters, numbers, spaces, and dashes'
+                );
+                return;
+            }
         }
         setConfigState({
             ...configState,
@@ -123,6 +127,12 @@ export default function ConfigTab({
 
     const submitChanges = (e: any) => {
         e.preventDefault();
+        if (!isValidName(configState.name)) {
+            alert(
+                'Invalid input: the name of a site must only contain alphabetical characters, numbers, spaces, and dashes'
+            );
+            return;
+        }
         updateSiteConfig(siteId, configState);
         alert('Changes saved!');
     };

--- a/src/components/Site/SiteConfigContent.tsx
+++ b/src/components/Site/SiteConfigContent.tsx
@@ -109,7 +109,7 @@ export default function ConfigTab({
     });
 
     const updateField = (e: any) => {
-        if (e.target.id === 'name' && isAlphabetical(e.currentTarget.value)) {
+        if (e.target.id === 'name' && !isAlphabetical(e.currentTarget.value)) {
             alert(
                 'Invalid input: the name of a site must only contain alphabetical characters'
             );

--- a/src/components/Site/SiteConfigContent.tsx
+++ b/src/components/Site/SiteConfigContent.tsx
@@ -28,6 +28,7 @@ import { ToggleSwitch } from 'components/Control/ToggleSwitch';
 import { Redirect } from 'react-router';
 import { useHistory } from 'react-router-dom';
 import PrivilegeAssert from 'components/Control/PrivilegeAssert';
+import { isAlphabetical } from 'scripts/DataValidation';
 
 interface configTabProps {
     site: SiteObject;
@@ -108,6 +109,12 @@ export default function ConfigTab({
     });
 
     const updateField = (e: any) => {
+        if (e.target.id === 'name' && isAlphabetical(e.currentTarget.value)) {
+            alert(
+                'Invalid input: the name of a site must only contain alphabetical characters'
+            );
+            return;
+        }
         setConfigState({
             ...configState,
             [e.currentTarget.name]: e.currentTarget.value,

--- a/src/components/Site/SiteEquipmentTab.tsx
+++ b/src/components/Site/SiteEquipmentTab.tsx
@@ -75,25 +75,10 @@ export default function SiteEquipmentTab(): ReactElement {
 
     // creates rows
     const rows = sites[siteID]['equipmentUnits'].map((unit) => {
-        // Pushes select option for types filter
-        let typeFound = false;
-        types.forEach((type) => {
-            if (type.id === unit.type) {
-                typeFound = true;
-            }
-        });
-        if (!typeFound) {
-            types.push({
-                id: unit.type,
-                label: unit.type,
-            });
-        }
-
         // pushes row for table
         return {
             name: unit.name,
             health: unit.health,
-            type: unit.type,
             key: unit.name,
             actions: (
                 <div className="actions">
@@ -131,7 +116,7 @@ export default function SiteEquipmentTab(): ReactElement {
         };
     });
 
-    const nameColumn = {
+    const nameEditColumn = {
         name: 'name',
         header: 'Name',
         defaultFlex: 9,
@@ -174,8 +159,14 @@ export default function SiteEquipmentTab(): ReactElement {
         },
     };
 
-    const columns: TypeColumn[] = [
-        nameColumn,
+    const nameStaticColumn = {
+        name: 'name',
+        header: 'Name',
+        defaultFlex: 9,
+        editable: false,
+    };
+
+    let columns: TypeColumn[] = [
         {
             name: 'health',
             header: 'Health',
@@ -188,23 +179,18 @@ export default function SiteEquipmentTab(): ReactElement {
             editable: false,
         },
         {
-            name: 'type',
-            header: 'Type',
-            defaultFlex: 3,
-            filterEditor: SelectFilter,
-            filterEditorProps: {
-                placeholder: 'All',
-                dataSource: types,
-            },
-            editable: false,
-        },
-        {
             name: 'actions',
             header: 'Actions',
             defaultFlex: 2,
             editable: false,
         },
     ];
+
+    if (privilege === 'User') {
+        columns.unshift(nameStaticColumn);
+    } else {
+        columns.unshift(nameEditColumn);
+    }
 
     const filters = [
         {
@@ -215,12 +201,6 @@ export default function SiteEquipmentTab(): ReactElement {
         },
         {
             name: 'health',
-            operator: 'eq',
-            type: 'select',
-            value: null,
-        },
-        {
-            name: 'type',
             operator: 'eq',
             type: 'select',
             value: null,

--- a/src/components/Site/SiteEquipmentTab.tsx
+++ b/src/components/Site/SiteEquipmentTab.tsx
@@ -224,7 +224,7 @@ export default function SiteEquipmentTab(): ReactElement {
     const onEditComplete = (info: TypeEditInfo) => {
         switch (info.columnId) {
             case 'name': {
-                if (isAlphabetical(info.value)) {
+                if (!isAlphabetical(info.value)) {
                     alert(
                         `Invalid equipment name: only alphabeitcal characters are allowed, reverting to old name`
                     );

--- a/src/components/Site/SiteEquipmentTab.tsx
+++ b/src/components/Site/SiteEquipmentTab.tsx
@@ -20,6 +20,7 @@ import pencilIcon from '../../assets/icons/pencil.svg';
 import deleteIcon from '../../assets/icons/delete.svg';
 import addIcon from '../../assets/icons/plus.svg';
 import PrivilegeAssert from 'components/Control/PrivilegeAssert';
+import { isAlphabetical } from '../../scripts/DataValidation';
 
 //Default number of items to display per datagrid page.
 const DEFAULT_PAGE_LIMIT = 10;
@@ -38,8 +39,6 @@ export default function SiteEquipmentTab(): ReactElement {
         { id: 'good', label: 'good' },
         { id: 'bad', label: 'bad' },
     ];
-
-    let types: Any[] = [];
 
     function getAllLoggerData() {
         var allData: any[] = [];
@@ -225,6 +224,12 @@ export default function SiteEquipmentTab(): ReactElement {
     const onEditComplete = (info: TypeEditInfo) => {
         switch (info.columnId) {
             case 'name': {
+                if (isAlphabetical(info.value)) {
+                    alert(
+                        `Invalid equipment name: only alphabeitcal characters are allowed, reverting to old name`
+                    );
+                    return;
+                }
                 let oldName = rows[info.rowIndex].name;
                 let newName = info.value;
                 if (privilege !== 'User') {

--- a/src/components/Site/SiteEquipmentTab.tsx
+++ b/src/components/Site/SiteEquipmentTab.tsx
@@ -20,7 +20,7 @@ import pencilIcon from '../../assets/icons/pencil.svg';
 import deleteIcon from '../../assets/icons/delete.svg';
 import addIcon from '../../assets/icons/plus.svg';
 import PrivilegeAssert from 'components/Control/PrivilegeAssert';
-import { isAlphabetical } from '../../scripts/DataValidation';
+import { isValidName } from '../../scripts/DataValidation';
 
 //Default number of items to display per datagrid page.
 const DEFAULT_PAGE_LIMIT = 10;
@@ -224,7 +224,7 @@ export default function SiteEquipmentTab(): ReactElement {
     const onEditComplete = (info: TypeEditInfo) => {
         switch (info.columnId) {
             case 'name': {
-                if (!isAlphabetical(info.value)) {
+                if (!isValidName(info.value)) {
                     alert(
                         `Invalid equipment name: only alphabeitcal characters are allowed, reverting to old name`
                     );

--- a/src/components/UserManagement.tsx
+++ b/src/components/UserManagement.tsx
@@ -23,6 +23,7 @@ import { User } from 'store/FirestoreInterfaces';
 import { TypeEditInfo } from '@inovua/reactdatagrid-community/types';
 import Button, { ButtonType } from './Control/Button';
 import pencilIcon from './../assets/icons/pencil.svg';
+import { isPhoneNumber } from '../scripts/DataValidation';
 
 //Default number of items to display per datagrid page.
 const DEFAULT_PAGE_LIMIT = 12;
@@ -226,6 +227,10 @@ export default function UserManagement(): ReactElement {
     const onEditComplete = (info: TypeEditInfo) => {
         switch (info.columnId) {
             case 'phone': {
+                if (!isPhoneNumber(info.value)) {
+                    alert('This phone number syntax is not recognized');
+                    return;
+                }
                 editPhoneNumber(info.rowId, info.value);
                 break;
             }

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -1,8 +1,8 @@
 /**
  * User Settings component.
- * 
+ *
  * Provides interface for changing account and notification settings.
- * 
+ *
  * Author: Brendan Ortmann
  */
 
@@ -55,11 +55,11 @@ function PasswordReset(): ReactElement {
                             type="password"
                             name="currentPassword"
                             id="currentPassword"
-                            placeholder="currentPassword"
+                            placeholder="current password"
                         />
                     </FormGroup>
                     <FormGroup className="inputGroup">
-                        <Label for="password">new password</Label>
+                        <Label for="password">New Password</Label>
                         <Input
                             required
                             type="password"
@@ -69,7 +69,7 @@ function PasswordReset(): ReactElement {
                         />
                     </FormGroup>
                     <FormGroup className="inputGroup">
-                        <Label for="confirmPassword">confirm password</Label>
+                        <Label for="confirmPassword">Confirm Password</Label>
                         <Input
                             required
                             type="password"

--- a/src/components/UserSettings.tsx
+++ b/src/components/UserSettings.tsx
@@ -17,6 +17,7 @@ import {
     updateUserDoc,
 } from 'scripts/Datastore';
 import { ToggleSwitch } from './Control/ToggleSwitch';
+import { isPhoneNumber } from 'scripts/DataValidation';
 
 /**
  * Generates password reset form and associated logic.
@@ -126,6 +127,12 @@ export default function Settings(): ReactElement {
 
     const submitChanges = (event: any) => {
         event.preventDefault();
+        if (!isPhoneNumber(newVals.phoneNumber)) {
+            alert(
+                'Invalid phone number syntax, please reformat. no changes were saved'
+            );
+            return;
+        }
         updateUserDoc(uid as string, newVals);
         alert('Changes saved!');
     };

--- a/src/scripts/DataValidation.ts
+++ b/src/scripts/DataValidation.ts
@@ -5,7 +5,7 @@
  */
 export function isAlphabetical(raw: string): boolean {
     // matches any aphabetical character uppercase or lowercase, and white space character
-    const expression = /[^a-z\s]/i;
+    const expression = /[a-z]/i;
     return expression.test(raw);
 }
 

--- a/src/scripts/DataValidation.ts
+++ b/src/scripts/DataValidation.ts
@@ -1,0 +1,28 @@
+/**
+ * Valid strings include capital or lowercase letters and white space characters
+ * @param raw
+ * @returns
+ */
+export function isAlphabetical(raw: string): boolean {
+    // matches any aphabetical character uppercase or lowercase, and white space character
+    const expression = /[^a-z\s]/i;
+    return expression.test(raw);
+}
+
+/**
+ * Returns true if the given text is a valid phone number
+ * valid phone number formats:
+ * (123) 456-7890
+ * (123)456-7890
+ * 123-456-7890
+ * 123.456.7890
+ * 1234567890
+ * +31636363634
+ * 075-63546725
+ * @param raw
+ * @returns boolean
+ */
+export function isPhoneNumber(raw: string): boolean {
+    const expression = /^[\+]?[(]?[0-9]{3}[)]?[-\s\.]?[0-9]{3}[-\s\.]?[0-9]{4,6}$/im;
+    return expression.test(raw);
+}

--- a/src/scripts/DataValidation.ts
+++ b/src/scripts/DataValidation.ts
@@ -1,12 +1,21 @@
 /**
- * Valid strings include capital or lowercase letters and white space characters
+ * Valid strings include:
+ * - capital alphabetical letters
+ * - lowercase alphabetical letters
+ * - white space characters: space, tab, newline
+ * - numbers 0 through 9
+ * - dashes
  * @param raw
  * @returns
  */
-export function isAlphabetical(raw: string): boolean {
+export function isValidName(raw: string): boolean {
     // matches any aphabetical character uppercase or lowercase, and white space character
-    const expression = /[a-z]/i;
-    return expression.test(raw);
+    if (raw.length === 0) {
+        return false;
+    }
+    const verifyNoInvalidCharacter = /[^a-z0-9\s-]/i;
+    const verifyAtLeastOne = /[a-z0-9]/i;
+    return !verifyNoInvalidCharacter.test(raw) && verifyAtLeastOne.test(raw);
 }
 
 /**


### PR DESCRIPTION
- If the user is of "User" privilege, the equipment name is rendered as text rather than as an input field
- Equipment name input and site name input are sanitized to only accept alphabetical characters and white space
- User management phone number input and user settings phone number input are sanitized to only accept valid phone numbers
