### PR TITLE
YADA-129 active status

### DIFF
--- a/src/components/Site/SiteEquipmentDashboard.tsx
+++ b/src/components/Site/SiteEquipmentDashboard.tsx
@@ -213,11 +213,13 @@ export default function EquipmentDashboard({
                 </Dropdown>
                 <CsvDownloadButton
                     headers={csvHeaders}
-                    filename={`${
-                        unit?.name ?? ''
-                    }_${new Date()
-                        .toLocaleDateString()
-                        .replace(/\//g, '-')}.csv`}
+                    filename={
+                        `${
+                            unit?.name ?? ''
+                        }_${new Date()
+                            .toLocaleDateString()
+                            .replace(/\//g, '-')}.csv`
+                    }
                     createData={() =>
                         aggregateDataFromLoggers(
                             loggersOnUnit,

--- a/src/components/Site/SiteEquipmentTab.tsx
+++ b/src/components/Site/SiteEquipmentTab.tsx
@@ -60,7 +60,7 @@ export default function SiteEquipmentTab(): ReactElement {
 
             if (logger)
                 loggerStatuses.push(
-                    <li> • {logger.name}: {computeStatus(logger)}</li>
+                    <li>{logger.name}: {computeStatus(logger)}</li>
                 );     
         });
 

--- a/src/components/Site/SiteEquipmentTab.tsx
+++ b/src/components/Site/SiteEquipmentTab.tsx
@@ -1,5 +1,4 @@
 // @ts-nocheck
-import SelectFilter from '@inovua/reactdatagrid-community/SelectFilter';
 import { TypeColumn } from '@inovua/reactdatagrid-community/types';
 import Button, { ButtonType } from 'components/Control/Button';
 import React, { ReactElement, useState } from 'react';
@@ -13,14 +12,15 @@ import {
 import { RootState } from 'store/rootReducer';
 import '@inovua/reactdatagrid-community/index.css';
 import ReactDataGrid from '@inovua/reactdatagrid-community';
-import chevron_right from '../../assets/icons/chevron_right.svg';
+import chevron_right from 'assets/icons/chevron_right.svg';
 import CsvDownloadButton from 'components/Control/CsvDownloadButton';
 import { Data } from 'react-csv/components/CommonPropTypes';
-import pencilIcon from '../../assets/icons/pencil.svg';
-import deleteIcon from '../../assets/icons/delete.svg';
-import addIcon from '../../assets/icons/plus.svg';
+import pencilIcon from 'assets/icons/pencil.svg';
+import deleteIcon from 'assets/icons/delete.svg';
 import PrivilegeAssert from 'components/Control/PrivilegeAssert';
-import { isValidName } from '../../scripts/DataValidation';
+import { isValidName } from 'scripts/DataValidation';
+import { EquipmentUnit, LoggerObject } from 'store/FirestoreInterfaces';
+import { timestampToDate } from 'scripts/DataTransformer';
 
 //Default number of items to display per datagrid page.
 const DEFAULT_PAGE_LIMIT = 10;
@@ -36,11 +36,42 @@ export default function SiteEquipmentTab(): ReactElement {
     const [redirect, changeRedirect] = useState('');
 
     const statuses = [
-        { id: 'good', label: 'good' },
-        { id: 'bad', label: 'bad' },
+        { id: 'disabled', label: 'DISABLED'},
+        { id: 'active', label: 'ACTIVE'},
+        { id: 'inactive', label: 'INACTIVE'},
     ];
 
-    function getAllLoggerData() {
+    // Computes the status type for the given logger
+    const computeStatus = (logger: LoggerObject) => {
+        const loggerTime: Date = timestampToDate(logger.data[logger.data.length-1]["timestamp"]);
+        const difference: number = new Date().getDay() - loggerTime.getDay();
+
+        if (!logger.status) return statuses[0].label;
+
+        return difference > 1 ? statuses[1].label : statuses[2].label;
+    }
+
+    // Creates list of logger statuses for given equipment unit
+    const loggerStatus = (unit: EquipmentUnit) => {
+        let loggerStatuses: ReactElement[] = [];
+            
+        unit.loggers.forEach((loggerId: string) => {
+            let logger: LoggerObject = loggers[loggerId];
+
+            if (logger)
+                loggerStatuses.push(
+                    <li> • {logger.name}: {computeStatus(logger)}</li>
+                );     
+        });
+
+        return loggerStatuses;
+    }
+
+    /**
+     * Aggregates data from all loggers into a single object.
+     * @returns {any[]} all the data in an array
+     */
+    function getAllLoggerData(): any[] {
         var allData: any[] = [];
 
         //add the header for logger id
@@ -77,7 +108,7 @@ export default function SiteEquipmentTab(): ReactElement {
         // pushes row for table
         return {
             name: unit.name,
-            health: unit.health,
+            status: loggerStatus(unit),
             key: unit.name,
             actions: (
                 <div className="actions">
@@ -115,6 +146,7 @@ export default function SiteEquipmentTab(): ReactElement {
         };
     });
 
+    // Defines name editing column, used if user has Power/Admin/Owner privileges
     const nameEditColumn = {
         name: 'name',
         header: 'Name',
@@ -132,23 +164,23 @@ export default function SiteEquipmentTab(): ReactElement {
                         type="text"
                         autoFocus={cellProps.inEdit}
                         value={v}
-                        onBlur={(e) => {
+                        onBlur={() => {
                             cellProps.editProps.onComplete();
                         }}
                         onChange={cellProps.editProps.onChange}
                         onFocus={() => cellProps.editProps.startEdit()}
-                        onKeyDown={(e) => {
-                            if (e.key === 'Escape') {
-                                cellProps.editProps.onCancel(e);
+                        onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
+                            if (event.key === 'Escape') {
+                                cellProps.editProps.onCancel(event);
                             }
-                            if (e.key === 'Enter') {
-                                cellProps.editProps.onComplete(e);
+                            if (event.key === 'Enter') {
+                                cellProps.editProps.onComplete(event);
                             }
-                            if (e.key == 'Tab') {
-                                e.preventDefault();
+                            if (event.key == 'Tab') {
+                                event.preventDefault();
                                 cellProps.editProps.onTabNavigation(
                                     true,
-                                    e.shiftKey ? -1 : 1
+                                    event.shiftKey ? -1 : 1
                                 );
                             }
                         }}
@@ -158,6 +190,7 @@ export default function SiteEquipmentTab(): ReactElement {
         },
     };
 
+    // If user has normal positions, simply display the name
     const nameStaticColumn = {
         name: 'name',
         header: 'Name',
@@ -165,16 +198,12 @@ export default function SiteEquipmentTab(): ReactElement {
         editable: false,
     };
 
+    // Other column definitions
     let columns: TypeColumn[] = [
         {
-            name: 'health',
-            header: 'Health',
+            name: 'status',
+            header: 'Status',
             defaultFlex: 3,
-            filterEditor: SelectFilter,
-            filterEditorProps: {
-                placeholder: 'All',
-                dataSource: statuses,
-            },
             editable: false,
         },
         {
@@ -185,12 +214,14 @@ export default function SiteEquipmentTab(): ReactElement {
         },
     ];
 
+    // Determines if user sees editable name column or static name column
     if (privilege === 'User') {
         columns.unshift(nameStaticColumn);
     } else {
         columns.unshift(nameEditColumn);
     }
 
+    // Default filter values
     const filters = [
         {
             name: 'name',
@@ -198,15 +229,12 @@ export default function SiteEquipmentTab(): ReactElement {
             type: 'string',
             value: '',
         },
-        {
-            name: 'health',
-            operator: 'eq',
-            type: 'select',
-            value: null,
-        },
     ];
 
-    function handleNewEquipmentClick() {
+    /**
+     * Creates a new equipment row in the data grid with default values.
+     */
+    function handleNewEquipmentClick(): void {
         let baseName = 'New Equipment ';
         let nameNum = 0;
 
@@ -221,20 +249,18 @@ export default function SiteEquipmentTab(): ReactElement {
         createNewEquipment(siteID, baseName + String(nameNum));
     }
 
+    // Handles name edit completion
     const onEditComplete = (info: TypeEditInfo) => {
-        switch (info.columnId) {
-            case 'name': {
-                if (!isValidName(info.value)) {
-                    alert(
-                        `Invalid equipment name: only alphabeitcal characters are allowed, reverting to old name`
-                    );
-                    return;
-                }
-                let oldName = rows[info.rowIndex].name;
-                let newName = info.value;
-                if (privilege !== 'User') {
-                    changeEquipmentName(siteID, oldName, newName);
-                }
+        if (info.columnId === 'name'){
+            if (!isValidName(info.value)) {
+                alert(
+                    `Invalid equipment name: only alphabetical characters are allowed, reverting to old name`
+                );
+                return;
+            }
+            
+            if (privilege !== 'User') {
+                changeEquipmentName(siteID, rows[info.rowIndex].name, info.value);
             }
         }
     };

--- a/src/scripts/DataTransformer.ts
+++ b/src/scripts/DataTransformer.ts
@@ -50,24 +50,34 @@ export function parseFilterString(filter: string): Date {
 
 /**
  * Checks if @param timestamp is greater than time given by @param filter.
- * @param timestamp string containing date and time in format specified 
- *        by @var timeParser
- * @param filter Date object specifying the time we're checking against
- * @returns boolean result of comparison
+ * @param {string} timestamp string containing date and time in format specified 
+ *        by DB
+ * @param {Date} filter Date object specifying the time we're checking against
+ * @returns {boolean} result of comparison
  */
 export function filterByDate(timestamp: string, filter: Date): boolean {
-    let timeParser = timeParse('%m-%d-%Y-%H:%M:%S'); // Should probably make this string a global constant somewhere
-    let parsedTime = timeParser(timestamp)?.getTime() ?? new Date().getTime();
+    return timestampToDate(timestamp).getTime() > filter.getTime();
+}
 
-    return parsedTime > filter.getTime();
+/**
+ * Converts @param timestamp (in format specified by logger data as in DB) to
+ * a @type {Date} object.
+ * @param {string} timestamp string containing date and time in format specified
+ *        by DB
+ * @returns {Date} Date object from parsed timestamp or a new Date object if the
+ *          parsed result is null
+ */
+export function timestampToDate(timestamp: string): Date {
+    let timeParser = timeParse('%m-%d-%Y-%H:%M:%S'); // Should probably make this string a global constant somewhere
+    return timeParser(timestamp) ?? new Date();
 }
 
 /**
  * Transforms a single data point into the format required by Nivo
- * @param data object containing channel names mapped to values
- * @param channelName the channel we're filtering by
- * @param filter the date we're filtering by
- * @returns object containing the filtered data in the format expected by Nivo
+ * @param {object} data object containing channel names mapped to values
+ * @param {string} channelName the channel we're filtering by
+ * @param {Date} filter the date we're filtering by
+ * @returns {object} object containing the filtered data in the format expected by Nivo
  */
 function transformDataPoint(
     data: {
@@ -91,9 +101,9 @@ function transformDataPoint(
 
 /**
  * Transforms an array of data objects into the format required by Nivo, filtered by a particular channel
- * @param data array of data objects
- * @param channelName the channel we're filtering by
- * @returns array of data objects in the format required by Nivo filtered by @param channelName
+ * @param {any[]} data array of data objects
+ * @param {string} channelName the channel we're filtering by
+ * @returns {any[]} array of data objects in the format required by Nivo filtered by channelName
  */
 export default function dataToNivoFormat(
     data: any[],
@@ -119,10 +129,10 @@ export default function dataToNivoFormat(
  * Gets all data associated with loggers in @param loggers, applies the
  * filter specified by @param filter, and returns an array containing
  * the data.
- * @param loggers array of Logger objects from which to pull data
- * @param filter (optional) Date object specifying the time period of data to
+ * @param {LoggerObject[]} loggers array of Logger objects from which to pull data
+ * @param {Date} filter (optional) Date object specifying the time period of data to
  *        pull from
- * @returns array of objects containing the data and the logger each piece
+ * @returns {any[]} array of objects containing the data and the logger each piece
  *          of data was pulled from
  */
 export function aggregateDataFromLoggers(


### PR DESCRIPTION
Replaces equipment "health" column with "status" column that lists the (computed) status of each logger attached to the unit, per Vance's request.

- Added additional comments throughout `SiteEquipmentTab.tsx`
- Abstracted `timestampToDate` method, to more easily convert timestamp in logger data to Date object