### PR TITLE
changed graph ticks to 30 minutes for now

### DIFF
--- a/src/components/Site/EquipmentDashboardCard.tsx
+++ b/src/components/Site/EquipmentDashboardCard.tsx
@@ -97,7 +97,7 @@ export default function DashboardCard({
           }}
           axisBottom={{
               format: '%H:%M',
-              tickValues: 'every 1 minute',
+              tickValues: 'every 30 minutes',
               orient: 'bottom',
               tickSize: 10,
               tickPadding: 5,


### PR DESCRIPTION
Changed graph ticks to 30 minutes for now, will look into changing them dynamically after the end of sprint 3.