### PR TITLE
Status clarification

### DIFF
--- a/src/components/Site/SiteEquipmentTab.tsx
+++ b/src/components/Site/SiteEquipmentTab.tsx
@@ -44,7 +44,7 @@ export default function SiteEquipmentTab(): ReactElement {
     // Computes the status type for the given logger
     const computeStatus = (logger: LoggerObject) => {
 
-        if (!logger.status) return statuses[0].label;
+        if (!logger.collectingData) return statuses[0].label;
         if (logger.data.length === 0) return statuses[2].label;
 
         const loggerTime: Date = timestampToDate(logger.data[logger.data.length-1].timestamp);


### PR DESCRIPTION
Switches `computeStatus` from looking at `logger.status` to `logger.collectingData`